### PR TITLE
Add unified encrypted save system and migrate main persisted UI flows

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -69,7 +69,7 @@
     },
     "dotnet.defaultSolution": "game.slnx",
     "workbench.colorCustomizations": {
-        "minimap.background": "#00000000",
-        "scrollbar.shadow": "#00000000"
+        "minimap.background": "#00000055",
+        "scrollbar.shadow": "#00000055"
     }
 }

--- a/Assets/Scripts/Editor.meta
+++ b/Assets/Scripts/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 98713d8ecdadcd442be29f397f72a0f3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Editor/SaveDataTools.cs
+++ b/Assets/Scripts/Editor/SaveDataTools.cs
@@ -1,0 +1,38 @@
+#if UNITY_EDITOR
+using System.IO;
+using UnityEditor;
+using UnityEngine;
+
+public static class SaveDataTools
+{
+    [MenuItem("Tools/Save Data/Delete All Saved Game Data")]
+    private static void DeleteAllSavedGameData()
+    {
+        string savesPath = Path.Combine(Application.persistentDataPath, SaveKeys.SavesFolderName);
+        bool confirmed = EditorUtility.DisplayDialog(
+            "Delete Saved Game Data",
+            $"This will delete save files in:\n{savesPath}\n\nand clear this project's active save slot preference.",
+            "Delete",
+            "Cancel");
+
+        if (!confirmed)
+        {
+            return;
+        }
+
+        if (Directory.Exists(savesPath))
+        {
+            Directory.Delete(savesPath, true);
+        }
+
+        PlayerPrefs.DeleteKey(SaveKeys.ActiveSlotPrefsKey);
+        PlayerPrefs.Save();
+        AssetDatabase.Refresh();
+
+        EditorUtility.DisplayDialog(
+            "Saved Game Data Deleted",
+            "All save-system data for this project has been removed.",
+            "OK");
+    }
+}
+#endif

--- a/Assets/Scripts/Editor/SaveDataTools.cs.meta
+++ b/Assets/Scripts/Editor/SaveDataTools.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a1f395c699d070a468b296111c3673cd

--- a/Assets/Scripts/Game/Player.cs
+++ b/Assets/Scripts/Game/Player.cs
@@ -7,7 +7,6 @@ using TypTyp.TextSystem;
 
 public class Player : NetworkBehaviour
 {
-    //public int PlayerID;
     public MatchManager MatchManager { get; private set; }
     public RitualManager RitualManager { get; private set; }
     public ManaGainManager ManaManager { get; private set; }
@@ -18,47 +17,49 @@ public class Player : NetworkBehaviour
     public CardUIManager CardUIManager { get; private set; }
     public PlayerInputManager PlayerInputManager { get; private set; }
     public ITextPipeline TextPipeline { get; private set; }
-    public static Player User { get; private set; } //Acceso global al Player del jugador
-    public static Player Enemy { get; private set; } //Acceso global al Player del enemigo
+    public static Player User { get; private set; }
+    public static Player Enemy { get; private set; }
 
-    //Las NetworkVariables de los jugadores est�n todas en el script Player, para su acceso 
-    //intuitivo y NetworkBehaviour centralizado
     public NetworkVariable<float> RitualProgress { get; private set; } = new();
     public NetworkVariable<float> CurrentMana { get; private set; } = new();
     public NetworkVariable<float> CurrentCorruption { get; private set; } = new();
 
     private void Awake()
     {
-        //Componentes del player
         GetComponents();
-
-        //Componentes de escena
         MatchManager = FindFirstObjectByType<MatchManager>();
     }
 
     public override void OnNetworkSpawn()
     {
-        RitualManager.enabled = IsOwner; //El ritual lo controla el cliente, evita mala UX por lag
-        ManaManager.enabled = IsServer; //La ganancia de man� la controla el server exclusivamente
-        CorruptionManager.enabled = IsServer; //La corrupci�n igual que el man�
+        RitualManager.enabled = IsOwner;
+        ManaManager.enabled = IsServer;
+        CorruptionManager.enabled = IsServer;
         CardUIManager.enabled = IsOwner;
 
         if (IsOwner)
         {
-            User = this; //Asignar user aqui permite utilizarlo en el Start de otros objetos del player
-            // NOTA: el nombre un futuro se puede obtener de los datos del jugador desde los servicios de Unity
-            FixedString32Bytes PlayerName = PlayerPrefs.GetString("Username");
-            Debug.Log(PlayerName);
+            User = this;
+
+            string playerNameValue = "AverageCultist";
+            if (SaveManager.Instance.TryGetSnapshot(out SaveState state) &&
+                !string.IsNullOrWhiteSpace(state.slot.profile.username))
+            {
+                playerNameValue = state.slot.profile.username;
+            }
+
+            FixedString32Bytes playerName = playerNameValue;
             int[] deck = CardRegister.Instance.GetIds(DeckBuilder.CardsInDeck);
-            PlayerData playerData = new(OwnerClientId, PlayerName, deck);
+            PlayerData playerData = new(OwnerClientId, playerName, deck);
 
             MatchManager.OnPlayerReadyRpc(playerData);
-            RitualManager.OnProgressUpdated += (p) => UpdateRitualProgressRpc(p);
+            RitualManager.OnProgressUpdated += progress => UpdateRitualProgressRpc(progress);
         }
+
         if (IsServer)
         {
-            ManaManager.OnManaGain += (m) => UpdateCurrentMana(m);
-            CorruptionManager.OnCorruptionGain += (c) => UpdateCurrentCorruption(c);
+            ManaManager.OnManaGain += mana => UpdateCurrentMana(mana);
+            CorruptionManager.OnCorruptionGain += corruption => UpdateCurrentCorruption(corruption);
         }
     }
 
@@ -68,25 +69,16 @@ public class Player : NetworkBehaviour
         DeckController.ConfigureServerDeckController(playerData.Deck);
     }
 
-    //Esto no llega al server en caso de un servidor dedicado
-    //el enabled de los componentes daria error
-    //solo funciona porque nuestro juego se supone para server hosts
     [Rpc(SendTo.ClientsAndHost)]
     public void ConfigurePlayerRpc(int playerIdx)
     {
-        //PlayerID = playerIdx == 0 ? TypTyp.Settings.Instance.P1_ID : TypTyp.Settings.Instance.P2_ID;
         this.tag = playerIdx == 0 ? Settings.Instance.P1_tag : Settings.Instance.P2_tag;
 
         FindFirstObjectByType<PlayerPositioner>().PositionPlayer(this, playerIdx, IsOwner);
-        // RitualManager.enabled = IsOwner; //El ritual lo controla el cliente, evita mala UX por lag
-        // ManaManager.enabled = IsServer; //La ganancia de man� la controla el server exclusivamente
-        // CorruptionManager.enabled = IsServer; //La corrupci�n igual que el man�
 
         if (IsOwner)
         {
             Enemy = FindObjectsByType<Player>(FindObjectsSortMode.None).First(p => p != this);
-            // User = this;
-
             FindFirstObjectByType<MatchManager>().NotifyPlayerConfiguredServerRpc();
         }
     }
@@ -99,11 +91,9 @@ public class Player : NetworkBehaviour
             CorruptionManager.ProcessMistake();
             return;
         }
-        //Como el ritual lo gestiona el cliente, en este método se debería agregar
-        //prevención de trampas antes de validar el progreso proporcionado
+
         RitualProgress.Value = progress;
 
-        // Servidor comprueba si alguien ha llegado al final
         if (RitualProgress.Value >= 1f) MatchManager.HandlePlayerVictory(this);
     }
 
@@ -115,14 +105,11 @@ public class Player : NetworkBehaviour
         if (value == Settings.Instance.MaxCorruption)
         {
             Player winner = MatchManager.GetPlayerById(MatchManager.GetPlayerId(this) == 0 ? 1 : 0);
-
             MatchManager.HandlePlayerVictory(winner);
         }
     }
 
-    #region Helper Methods
-
-    void GetComponents()
+    private void GetComponents()
     {
         RitualManager = GetComponentInChildren<RitualManager>();
         ManaManager = GetComponent<ManaGainManager>();
@@ -143,5 +130,4 @@ public class Player : NetworkBehaviour
         UnityEngine.Assertions.Assert.IsNotNull(CardUIManager);
         UnityEngine.Assertions.Assert.IsNotNull(PlayerInputManager);
     }
-    #endregion
 }

--- a/Assets/Scripts/Resources/SaveManager.asset
+++ b/Assets/Scripts/Resources/SaveManager.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4ef48790279d6d14d993f3a1395e0afa, type: 3}
+  m_Name: SaveManager
+  m_EditorClassIdentifier: Assembly-CSharp::SaveManager

--- a/Assets/Scripts/Resources/SaveManager.asset.meta
+++ b/Assets/Scripts/Resources/SaveManager.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a1aa2417edf4bda4c8374dd8570bf98d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/SaveSystem.meta
+++ b/Assets/Scripts/SaveSystem.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 691dfc5230c1cf5428237696a4aaae47
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/SaveSystem/FileSaveBackend.cs
+++ b/Assets/Scripts/SaveSystem/FileSaveBackend.cs
@@ -1,0 +1,90 @@
+using System;
+using System.IO;
+using UnityEngine;
+
+public class FileSaveBackend : ISaveBackend
+{
+    private readonly string rootPath;
+
+    public FileSaveBackend()
+    {
+        rootPath = Path.Combine(Application.persistentDataPath, SaveKeys.SavesFolderName);
+
+        try
+        {
+            Directory.CreateDirectory(rootPath);
+        }
+        catch (Exception exception)
+        {
+            Debug.LogError($"[FileSaveBackend] Failed to create save directory '{rootPath}': {exception.Message}");
+        }
+    }
+
+    public void Save(string key, string data)
+    {
+        try
+        {
+            Directory.CreateDirectory(rootPath);
+            string encrypted = SaveEncryption.EncryptForStorage(data);
+            File.WriteAllText(GetPath(key), encrypted);
+        }
+        catch (Exception exception)
+        {
+            Debug.LogError($"[FileSaveBackend] Failed to save key '{key}': {exception.Message}");
+        }
+    }
+
+    public string Load(string key)
+    {
+        try
+        {
+            string path = GetPath(key);
+            if (!File.Exists(path))
+            {
+                return string.Empty;
+            }
+
+            string stored = File.ReadAllText(path);
+            return SaveEncryption.DecryptFromStorage(stored, $"file key '{key}'");
+        }
+        catch (Exception exception)
+        {
+            Debug.LogWarning($"[FileSaveBackend] Failed to load key '{key}': {exception.Message}");
+            return string.Empty;
+        }
+    }
+
+    public bool Exists(string key)
+    {
+        try
+        {
+            return File.Exists(GetPath(key));
+        }
+        catch (Exception exception)
+        {
+            Debug.LogWarning($"[FileSaveBackend] Failed to check key '{key}': {exception.Message}");
+            return false;
+        }
+    }
+
+    public void Delete(string key)
+    {
+        try
+        {
+            string path = GetPath(key);
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+        catch (Exception exception)
+        {
+            Debug.LogWarning($"[FileSaveBackend] Failed to delete key '{key}': {exception.Message}");
+        }
+    }
+
+    private string GetPath(string key)
+    {
+        return Path.Combine(rootPath, key + ".json");
+    }
+}

--- a/Assets/Scripts/SaveSystem/FileSaveBackend.cs.meta
+++ b/Assets/Scripts/SaveSystem/FileSaveBackend.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: cf3b0148032999046b4fd4f94d2670ef

--- a/Assets/Scripts/SaveSystem/GlobalSettingsData.cs
+++ b/Assets/Scripts/SaveSystem/GlobalSettingsData.cs
@@ -1,0 +1,11 @@
+using System;
+
+[Serializable]
+public class GlobalSettingsData
+{
+    public bool showSpaces = true;
+    public bool capsLockWarning;
+    public float volume = 0.75f;
+    public int fontIndex;
+    public bool initialTipUnderstood;
+}

--- a/Assets/Scripts/SaveSystem/GlobalSettingsData.cs.meta
+++ b/Assets/Scripts/SaveSystem/GlobalSettingsData.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2bf0073e66de9d341a061a81b7dc5065

--- a/Assets/Scripts/SaveSystem/ISaveBackend.cs
+++ b/Assets/Scripts/SaveSystem/ISaveBackend.cs
@@ -1,0 +1,7 @@
+public interface ISaveBackend
+{
+    void Save(string key, string data);
+    string Load(string key);
+    bool Exists(string key);
+    void Delete(string key);
+}

--- a/Assets/Scripts/SaveSystem/ISaveBackend.cs.meta
+++ b/Assets/Scripts/SaveSystem/ISaveBackend.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 77982a1c751b0ca46832b8a0a8eb9de1

--- a/Assets/Scripts/SaveSystem/PlayerPrefsSaveBackend.cs
+++ b/Assets/Scripts/SaveSystem/PlayerPrefsSaveBackend.cs
@@ -1,0 +1,59 @@
+using System;
+using UnityEngine;
+
+public class PlayerPrefsSaveBackend : ISaveBackend
+{
+    public void Save(string key, string data)
+    {
+        try
+        {
+            string encrypted = SaveEncryption.EncryptForStorage(data);
+            PlayerPrefs.SetString(key, encrypted);
+            PlayerPrefs.Save();
+        }
+        catch (Exception exception)
+        {
+            Debug.LogError($"[PlayerPrefsSaveBackend] Failed to save key '{key}': {exception.Message}");
+        }
+    }
+
+    public string Load(string key)
+    {
+        try
+        {
+            string stored = PlayerPrefs.GetString(key, string.Empty);
+            return SaveEncryption.DecryptFromStorage(stored, $"player prefs key '{key}'");
+        }
+        catch (Exception exception)
+        {
+            Debug.LogWarning($"[PlayerPrefsSaveBackend] Failed to load key '{key}': {exception.Message}");
+            return string.Empty;
+        }
+    }
+
+    public bool Exists(string key)
+    {
+        try
+        {
+            return PlayerPrefs.HasKey(key);
+        }
+        catch (Exception exception)
+        {
+            Debug.LogWarning($"[PlayerPrefsSaveBackend] Failed to check key '{key}': {exception.Message}");
+            return false;
+        }
+    }
+
+    public void Delete(string key)
+    {
+        try
+        {
+            PlayerPrefs.DeleteKey(key);
+            PlayerPrefs.Save();
+        }
+        catch (Exception exception)
+        {
+            Debug.LogWarning($"[PlayerPrefsSaveBackend] Failed to delete key '{key}': {exception.Message}");
+        }
+    }
+}

--- a/Assets/Scripts/SaveSystem/PlayerPrefsSaveBackend.cs.meta
+++ b/Assets/Scripts/SaveSystem/PlayerPrefsSaveBackend.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0180fcb9e11ebe94384781b56927b336

--- a/Assets/Scripts/SaveSystem/SaveData.cs
+++ b/Assets/Scripts/SaveSystem/SaveData.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+
+[Serializable]
+public class SaveData
+{
+    public int version = 1;
+    public ProfileSaveData profile = new();
+    public DeckSaveData deck = new();
+}
+
+[Serializable]
+public class SaveState
+{
+    public SaveData slot = new();
+    public GlobalSettingsData global = new();
+}
+
+[Serializable]
+public class ProfileSaveData
+{
+    public string username = string.Empty;
+}
+
+[Serializable]
+public class DeckSaveData
+{
+    public List<int> equippedCardIds = new();
+}

--- a/Assets/Scripts/SaveSystem/SaveData.cs.meta
+++ b/Assets/Scripts/SaveSystem/SaveData.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ee3a2b311a18fc74787a9b0a6f32b510

--- a/Assets/Scripts/SaveSystem/SaveEncryption.cs
+++ b/Assets/Scripts/SaveSystem/SaveEncryption.cs
@@ -1,0 +1,84 @@
+using System;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+using UnityEngine;
+
+public static class SaveEncryption
+{
+    private const string Password = "Typtyp";
+    private const string Prefix = "ENC1|";
+
+    public static string EncryptForStorage(string plainText)
+    {
+        string normalized = plainText ?? string.Empty;
+        return Prefix + Encrypt(normalized);
+    }
+
+    public static string DecryptFromStorage(string storedValue, string context)
+    {
+        if (string.IsNullOrEmpty(storedValue))
+        {
+            return string.Empty;
+        }
+
+        if (!storedValue.StartsWith(Prefix, StringComparison.Ordinal))
+        {
+            return storedValue;
+        }
+
+        try
+        {
+            return Decrypt(storedValue.Substring(Prefix.Length));
+        }
+        catch (Exception exception)
+        {
+            Debug.LogWarning($"[SaveEncryption] Failed to decrypt {context}: {exception.Message}");
+            return string.Empty;
+        }
+    }
+
+    private static string Encrypt(string plainText)
+    {
+        byte[] key = SHA256.Create().ComputeHash(Encoding.UTF8.GetBytes(Password));
+
+        using Aes aes = Aes.Create();
+        aes.Key = key;
+        aes.GenerateIV();
+
+        using MemoryStream memoryStream = new();
+        memoryStream.Write(aes.IV, 0, aes.IV.Length);
+
+        using (CryptoStream cryptoStream = new(memoryStream, aes.CreateEncryptor(), CryptoStreamMode.Write))
+        using (StreamWriter writer = new(cryptoStream))
+        {
+            writer.Write(plainText);
+        }
+
+        return Convert.ToBase64String(memoryStream.ToArray());
+    }
+
+    private static string Decrypt(string cipherText)
+    {
+        byte[] fullCipher = Convert.FromBase64String(cipherText);
+        if (fullCipher.Length < 16)
+        {
+            throw new Exception("Cipher text too short.");
+        }
+
+        byte[] key = SHA256.Create().ComputeHash(Encoding.UTF8.GetBytes(Password));
+
+        using Aes aes = Aes.Create();
+        aes.Key = key;
+
+        byte[] iv = new byte[16];
+        Array.Copy(fullCipher, 0, iv, 0, iv.Length);
+        aes.IV = iv;
+
+        using MemoryStream memoryStream = new(fullCipher, iv.Length, fullCipher.Length - iv.Length);
+        using CryptoStream cryptoStream = new(memoryStream, aes.CreateDecryptor(), CryptoStreamMode.Read);
+        using StreamReader reader = new(cryptoStream);
+
+        return reader.ReadToEnd();
+    }
+}

--- a/Assets/Scripts/SaveSystem/SaveEncryption.cs.meta
+++ b/Assets/Scripts/SaveSystem/SaveEncryption.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 74ba836e195a39c42bc787d9000d02bf

--- a/Assets/Scripts/SaveSystem/SaveKeys.cs
+++ b/Assets/Scripts/SaveSystem/SaveKeys.cs
@@ -1,0 +1,13 @@
+public static class SaveKeys
+{
+    public const string DefaultSlotId = "slot_0";
+    public const string ActiveSlotPrefsKey = "save_active_slot";
+    public const string GlobalSettingsKey = "global_settings";
+    public const string SlotPrefix = "save_slot_";
+    public const string SavesFolderName = "Saves";
+
+    public static string GetSlotKey(string slotId)
+    {
+        return SlotPrefix + slotId;
+    }
+}

--- a/Assets/Scripts/SaveSystem/SaveKeys.cs.meta
+++ b/Assets/Scripts/SaveSystem/SaveKeys.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7b73de481df05b64a8d88dee950e1cc3

--- a/Assets/Scripts/SaveSystem/SaveManager.cs
+++ b/Assets/Scripts/SaveSystem/SaveManager.cs
@@ -1,0 +1,241 @@
+using System;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+[NoAutoCreate]
+[CreateAssetMenu(fileName = nameof(SaveManager), menuName = "TypTyp/SaveManager")]
+public class SaveManager : ScriptableSingleton<SaveManager>
+{
+    private ISaveBackend backend;
+    private SaveState currentState;
+    private string activeSlotId;
+    private bool initialLoadPending;
+    private bool isInitialized;
+
+    public event Action<SaveState> OnBeforeSave;
+    public event Action<SaveState> OnAfterLoad;
+
+    public bool HasLoadedState { get; private set; }
+    public string ActiveSlotId => activeSlotId;
+
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+    private static void InitializeRuntime()
+    {
+        Instance.ResetRuntimeState();
+        Instance.EnsureInitialized();
+    }
+
+    private void OnDisable()
+    {
+        SceneManager.sceneLoaded -= HandleInitialSceneLoaded;
+        isInitialized = false;
+    }
+
+    public bool HasActiveSlot()
+    {
+        EnsureInitialized();
+        return !string.IsNullOrWhiteSpace(activeSlotId);
+    }
+
+    public void CreateSlot(string slotId)
+    {
+        EnsureInitialized();
+        SetActiveSlot(slotId);
+
+        SaveData data = NormalizeSlotData(new SaveData());
+        SaveDataInternal(data);
+        currentState.slot = DeepCopy(data);
+        HasLoadedState = true;
+        OnAfterLoad?.Invoke(GetSnapshot());
+    }
+
+    public void SetActiveSlot(string slotId)
+    {
+        EnsureInitialized();
+        if (string.IsNullOrWhiteSpace(slotId))
+        {
+            Debug.LogWarning("[SaveManager] Tried to set an empty slot id.");
+            return;
+        }
+
+        activeSlotId = slotId;
+        PlayerPrefs.SetString(SaveKeys.ActiveSlotPrefsKey, activeSlotId);
+        PlayerPrefs.Save();
+    }
+
+    public void Save()
+    {
+        EnsureInitialized();
+        EnsureActiveSlot();
+
+        SaveState state = NormalizeState(GetSnapshot() ?? new SaveState());
+        OnBeforeSave?.Invoke(state);
+        NormalizeState(state);
+
+        SaveDataInternal(state.slot);
+        SaveGlobalSettingsInternal(state.global);
+        currentState = DeepCopy(state);
+        HasLoadedState = true;
+    }
+
+    public void Load()
+    {
+        EnsureInitialized();
+        EnsureActiveSlot();
+
+        SaveData loadedData = new SaveData();
+        if (backend.Exists(SaveKeys.GetSlotKey(activeSlotId)))
+        {
+            string json = backend.Load(SaveKeys.GetSlotKey(activeSlotId));
+            loadedData = DeserializeOrDefault(json, new SaveData(), "slot save");
+        }
+
+        currentState.slot = NormalizeSlotData(loadedData);
+        LoadGlobalSettingsInternal();
+        currentState = NormalizeState(currentState);
+        HasLoadedState = true;
+        OnAfterLoad?.Invoke(GetSnapshot());
+    }
+
+    public bool TryGetSnapshot(out SaveState state)
+    {
+        EnsureInitialized();
+        state = HasLoadedState ? GetSnapshot() : null;
+        return state != null;
+    }
+
+    private void EnsureInitialized()
+    {
+        if (isInitialized)
+        {
+            return;
+        }
+
+        backend = CreateBackend();
+        currentState = NormalizeState(new SaveState());
+        activeSlotId = PlayerPrefs.GetString(SaveKeys.ActiveSlotPrefsKey, SaveKeys.DefaultSlotId);
+        LoadGlobalSettingsInternal();
+
+        initialLoadPending = backend.Exists(SaveKeys.GetSlotKey(activeSlotId));
+        SceneManager.sceneLoaded -= HandleInitialSceneLoaded;
+        SceneManager.sceneLoaded += HandleInitialSceneLoaded;
+        isInitialized = true;
+    }
+
+    private void ResetRuntimeState()
+    {
+        SceneManager.sceneLoaded -= HandleInitialSceneLoaded;
+        backend = null;
+        currentState = null;
+        activeSlotId = string.Empty;
+        initialLoadPending = false;
+        HasLoadedState = false;
+        isInitialized = false;
+    }
+
+    private void HandleInitialSceneLoaded(Scene scene, LoadSceneMode loadSceneMode)
+    {
+        SceneManager.sceneLoaded -= HandleInitialSceneLoaded;
+
+        if (initialLoadPending)
+        {
+            initialLoadPending = false;
+            Load();
+            return;
+        }
+
+        currentState = NormalizeState(currentState);
+        HasLoadedState = true;
+        OnAfterLoad?.Invoke(GetSnapshot());
+    }
+
+    private void EnsureActiveSlot()
+    {
+        if (!HasActiveSlot())
+        {
+            SetActiveSlot(SaveKeys.DefaultSlotId);
+        }
+    }
+
+    private void SaveDataInternal(SaveData data)
+    {
+        backend.Save(SaveKeys.GetSlotKey(activeSlotId), JsonUtility.ToJson(NormalizeSlotData(data), true));
+    }
+
+    private void LoadGlobalSettingsInternal()
+    {
+        if (!backend.Exists(SaveKeys.GlobalSettingsKey))
+        {
+            currentState.global = new GlobalSettingsData();
+            return;
+        }
+
+        string json = backend.Load(SaveKeys.GlobalSettingsKey);
+        currentState.global = DeserializeOrDefault(json, new GlobalSettingsData(), "global settings");
+    }
+
+    private void SaveGlobalSettingsInternal(GlobalSettingsData data)
+    {
+        string json = JsonUtility.ToJson(data ?? new GlobalSettingsData(), true);
+        backend.Save(SaveKeys.GlobalSettingsKey, json);
+    }
+
+    private static ISaveBackend CreateBackend()
+    {
+#if UNITY_WEBGL && !UNITY_EDITOR
+        return new PlayerPrefsSaveBackend();
+#else
+        return new FileSaveBackend();
+#endif
+    }
+
+    private SaveState GetSnapshot()
+    {
+        return DeepCopy(NormalizeState(currentState));
+    }
+
+    private static SaveState NormalizeState(SaveState state)
+    {
+        state ??= new SaveState();
+        state.slot = NormalizeSlotData(state.slot);
+        state.global ??= new GlobalSettingsData();
+        return state;
+    }
+
+    private static SaveData NormalizeSlotData(SaveData data)
+    {
+        data ??= new SaveData();
+        data.profile ??= new ProfileSaveData();
+        data.deck ??= new DeckSaveData();
+        data.deck.equippedCardIds ??= new System.Collections.Generic.List<int>();
+        return data;
+    }
+
+    private static T DeserializeOrDefault<T>(string json, T fallback, string context) where T : class
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return fallback;
+        }
+
+        try
+        {
+            return JsonUtility.FromJson<T>(json) ?? fallback;
+        }
+        catch (Exception exception)
+        {
+            Debug.LogWarning($"[SaveManager] Failed to deserialize {context}: {exception.Message}");
+            return fallback;
+        }
+    }
+
+    private static T DeepCopy<T>(T source) where T : class
+    {
+        if (source == null)
+        {
+            return null;
+        }
+
+        return DeserializeOrDefault(JsonUtility.ToJson(source), source, typeof(T).Name);
+    }
+}

--- a/Assets/Scripts/SaveSystem/SaveManager.cs.meta
+++ b/Assets/Scripts/SaveSystem/SaveManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4ef48790279d6d14d993f3a1395e0afa

--- a/Assets/Scripts/Spells/DeckBuilder.cs
+++ b/Assets/Scripts/Spells/DeckBuilder.cs
@@ -17,24 +17,50 @@ public class DeckBuilder : MonoBehaviour
     private BuilderDisplayer selectedUnequipped;
     public static CardDefinition[] CardsInDeck { get; private set; }
 
+    private void OnEnable()
+    {
+        SaveManager.Instance.OnBeforeSave += HandleBeforeSave;
+        SaveManager.Instance.OnAfterLoad += HandleAfterLoad;
+    }
+
     private void Awake()
     {
-        LoadEquippedCards();
-        CardsInDeck = equippedCards.Select(c => c.Card).ToArray();
-        LoadUnequippedCards();
-        foreach (GameObject panel in highlightPanels) 
-            panel.transform.SetAsLastSibling(); //Para estar por encima de las cartas creadas
+        InitializeEquippedCards();
+
+        if (SaveManager.Instance.TryGetSnapshot(out SaveState state))
+        {
+            ApplyDeck(state);
+        }
+        else
+        {
+            ApplyDeck(new SaveState());
+        }
+
+        foreach (GameObject panel in highlightPanels)
+        {
+            panel.transform.SetAsLastSibling();
+        }
+
         BuilderDisplayer.OnCardChosen += ProcessCardChosen;
     }
 
-    private void OnDestroy() => BuilderDisplayer.OnCardChosen -= ProcessCardChosen;
+    private void OnDisable()
+    {
+        if (SaveManager.Instance == null) return;
+
+        SaveManager.Instance.OnBeforeSave -= HandleBeforeSave;
+        SaveManager.Instance.OnAfterLoad -= HandleAfterLoad;
+    }
+
+    private void OnDestroy()
+    {
+        BuilderDisplayer.OnCardChosen -= ProcessCardChosen;
+    }
 
     public void SaveEquippedCards()
     {
-        List<int> indexes = equippedCards.Select(c => CardRegister.Instance.GetId(c.Card)).ToList();
-        string eCardsString = string.Join(",", indexes);
-        PlayerPrefsEncoder.SetString("EquippedCards", eCardsString);
-        CardsInDeck = equippedCards.Select(c => c.Card).ToArray();
+        RefreshCardsInDeck();
+        SaveManager.Instance.Save();
     }
 
     public void ResetSelection()
@@ -46,60 +72,46 @@ public class DeckBuilder : MonoBehaviour
         foreach (GameObject panel in highlightPanels) panel.SetActive(false);
     }
 
-    private void LoadEquippedCards()
+    private void InitializeEquippedCards()
     {
-        //Creaci�n de cartas:
         for (int i = 0; i < Settings.Instance.DeckSize; i++)
         {
-            BuilderDisplayer c = Instantiate(cardPrefab, equippedLayout).GetComponent<BuilderDisplayer>();
-            equippedCards.Add(c);
-        }
-        //Carga de cartas guardadas:
-        equippedIndexes = Enumerable.Range(0, Settings.Instance.DeckSize).ToList();
-        string eCardsString = PlayerPrefsEncoder.GetString("EquippedCards", string.Empty);
-        if (!eCardsString.Equals(string.Empty))
-            equippedIndexes = eCardsString.Split(',').Select(int.Parse).ToList();
-        //Manejo de disminuci�n de deck size:
-        if (Settings.Instance.DeckSize < equippedIndexes.Count)
-            equippedIndexes.RemoveRange(Settings.Instance.DeckSize - 1,
-                equippedIndexes.Count - Settings.Instance.DeckSize);
-        //Configuraci�n de cartas:
-        for (int i = 0; i < equippedIndexes.Count; i++)
-                equippedCards[i].SetInfo(CardRegister.Instance.GetById(equippedIndexes[i]));
-        //Manejo de aumento de deck size:
-        if(equippedIndexes.Count < equippedCards.Count)
-        {
-            int count = equippedCards.Count - equippedIndexes.Count;
-            for(int i = 0; i < count; i++)
-            {
-                List<CardDefinition> currentCards = equippedCards.Select(c => c.Card).ToList();
-                (CardDefinition c, int idx) = CardRegister.Instance.GetUncontainedItem(currentCards);
-                equippedCards[equippedIndexes.Count].SetInfo(c);
-                equippedIndexes.Add(idx);
-            }
+            BuilderDisplayer card = Instantiate(cardPrefab, equippedLayout).GetComponent<BuilderDisplayer>();
+            equippedCards.Add(card);
         }
     }
 
-    private void LoadUnequippedCards()
+    private void RebuildUnequippedCards()
     {
-        for(int i = 0; i < CardRegister.Instance.Count; i++)
+        foreach (BuilderDisplayer card in unequippedCards)
+        {
+            if (card != null)
+            {
+                Destroy(card.gameObject);
+            }
+        }
+
+        unequippedCards.Clear();
+
+        for (int i = 0; i < CardRegister.Instance.Count; i++)
         {
             if (equippedIndexes.Contains(i)) continue;
-            BuilderDisplayer c = Instantiate(cardPrefab, unequippedLayout).GetComponent<BuilderDisplayer>();
-            unequippedCards.Add(c);
-            c.SetInfo(CardRegister.Instance.GetById(i));
+            BuilderDisplayer card = Instantiate(cardPrefab, unequippedLayout).GetComponent<BuilderDisplayer>();
+            unequippedCards.Add(card);
+            card.SetInfo(CardRegister.Instance.GetById(i));
         }
     }
 
     private void ProcessCardChosen(BuilderDisplayer card)
     {
-        StartCoroutine(ResetButtonsCoroutine()); //Se resetean los botones para resetear su escritura
+        StartCoroutine(ResetButtonsCoroutine());
         if (card == selectedEquipped || card == selectedUnequipped)
         {
             ResetSelection();
             return;
         }
-        if(card.transform.parent == equippedLayout)
+
+        if (card.transform.parent == equippedLayout)
         {
             selectedEquipped?.Highlight(false);
             selectedEquipped = card;
@@ -109,27 +121,94 @@ public class DeckBuilder : MonoBehaviour
             selectedUnequipped?.Highlight(false);
             selectedUnequipped = card;
         }
-        card.Highlight(true); //Lo pone como �ltimo hijo, delante de highlight panel
+
+        card.Highlight(true);
         CheckCardChange();
-        //Si alg�n objeto est� en hover (ser� �ltimo hijo) el panel se activa
-        foreach (GameObject panel in highlightPanels) 
+        foreach (GameObject panel in highlightPanels)
+        {
             panel.SetActive(panel.transform.GetSiblingIndex() != panel.transform.parent.childCount - 1);
+        }
     }
 
     private void CheckCardChange()
     {
         if (selectedUnequipped && selectedEquipped)
         {
-            CardDefinition c = selectedUnequipped.Card;
+            CardDefinition card = selectedUnequipped.Card;
             selectedUnequipped.SetInfo(selectedEquipped.Card);
-            selectedEquipped.SetInfo(c);
+            selectedEquipped.SetInfo(card);
+            RefreshIndexesFromUI();
+            RefreshCardsInDeck();
             ResetSelection();
         }
     }
 
-    IEnumerator ResetButtonsCoroutine()
+    private IEnumerator ResetButtonsCoroutine()
     {
         yield return null;
-        foreach (var b in GetComponentsInChildren<WritableButton>()) b.ResetButton();
+        foreach (WritableButton button in GetComponentsInChildren<WritableButton>()) button.ResetButton();
+    }
+
+    private void HandleBeforeSave(SaveState state)
+    {
+        RefreshIndexesFromUI();
+        RefreshCardsInDeck();
+        state.slot.deck.equippedCardIds = equippedIndexes.ToList();
+    }
+
+    private void HandleAfterLoad(SaveState state)
+    {
+        ApplyDeck(state);
+    }
+
+    private void ApplyDeck(SaveState state)
+    {
+        equippedIndexes = ResolveEquippedIndexes(state?.slot?.deck?.equippedCardIds);
+
+        for (int i = 0; i < equippedCards.Count; i++)
+        {
+            equippedCards[i].SetInfo(CardRegister.Instance.GetById(equippedIndexes[i]));
+        }
+
+        RebuildUnequippedCards();
+        RefreshCardsInDeck();
+        ResetSelection();
+    }
+
+    private List<int> ResolveEquippedIndexes(List<int> savedIndexes)
+    {
+        List<int> resolved = new();
+        if (savedIndexes != null)
+        {
+            resolved = savedIndexes
+                .Where(index => index >= 0 && index < CardRegister.Instance.Count)
+                .Distinct()
+                .Take(Settings.Instance.DeckSize)
+                .ToList();
+        }
+
+        if (resolved.Count == 0)
+        {
+            resolved = Enumerable.Range(0, Mathf.Min(Settings.Instance.DeckSize, CardRegister.Instance.Count)).ToList();
+        }
+
+        while (resolved.Count < equippedCards.Count)
+        {
+            List<CardDefinition> currentCards = resolved.Select(CardRegister.Instance.GetById).ToList();
+            (CardDefinition card, int idx) = CardRegister.Instance.GetUncontainedItem(currentCards);
+            resolved.Add(idx);
+        }
+
+        return resolved;
+    }
+
+    private void RefreshIndexesFromUI()
+    {
+        equippedIndexes = equippedCards.Select(card => CardRegister.Instance.GetId(card.Card)).ToList();
+    }
+
+    private void RefreshCardsInDeck()
+    {
+        CardsInDeck = equippedCards.Select(card => card.Card).ToArray();
     }
 }

--- a/Assets/Scripts/UI/AdaptiveGridLayout.cs
+++ b/Assets/Scripts/UI/AdaptiveGridLayout.cs
@@ -24,64 +24,61 @@ public class AdaptiveGridLayout : MonoBehaviour
 #if UNITY_EDITOR
     private void OnEnable()
     {
-        rectTransform = GetComponent<RectTransform>();
-        children.Clear();
-        for (int i = 0; i < transform.childCount; i++)
-        {
-            if (excludedObjects.Contains(transform.GetChild(i))) continue;
-            RectTransform rt = transform.GetChild(i).GetComponent<RectTransform>();
-            rt.anchorMin = new Vector2(0f, 1f);
-            rt.anchorMax = new Vector2(0f, 1f);
-            children.Add(rt);
-        }
+        RefreshChildren();
     }
 #endif
 
     private void Start()
     {
-        rectTransform = GetComponent<RectTransform>();
-        children.Clear();
-        for (int i = 0; i < transform.childCount; i++)
-        {
-            if (excludedObjects.Contains(transform.GetChild(i))) continue;
-            RectTransform rt = transform.GetChild(i).GetComponent<RectTransform>();
-            rt.anchorMin = new Vector2(0f, 1f);
-            rt.anchorMax = new Vector2(0f, 1f);
-            children.Add(rt);
-        }
+        RefreshChildren();
+    }
+
+    private void OnTransformChildrenChanged()
+    {
+        RefreshChildren();
     }
 
     private void LateUpdate()
     {
-        //Cálculo de espacio disponible para las cartas:
+        if (rectTransform == null)
+        {
+            rectTransform = GetComponent<RectTransform>();
+        }
+
+        children.RemoveAll(child => child == null);
+        if (rectTransform == null || children.Count == 0 || numColumns <= 0)
+        {
+            return;
+        }
+
         int numRows = (int)Mathf.Ceil((float)children.Count / numColumns);
         float horizontalPadding = rectTransform.rect.width * horizontalPaddingPercentaje;
         float verticalPadding = rectTransform.rect.height * verticalPaddingPercentaje;
         float horizontalSpacing = horizontalSpacingPercentaje * rectTransform.rect.width;
         float verticalSpacing = verticalSpacingPercentaje * rectTransform.rect.height;
-        float availableVertSpace = rectTransform.rect.height - 2 * verticalPadding - 
+        float availableVertSpace = rectTransform.rect.height - 2 * verticalPadding -
             (numRows - 1) * verticalSpacing;
         float availableHorSpace = rectTransform.rect.width - 2 * horizontalPadding -
             (numColumns - 1) * horizontalSpacing;
-        //Cálculo tamaño de las cartas:
+
         float targetHeight = availableVertSpace / numRows;
         float targetWidth = availableHorSpace / numColumns;
         float targetRatio = targetHeight / targetWidth;
-        //Conservación del aspect ratio:
+
         if (targetRatio > cellRatio) targetHeight = cellRatio * targetWidth;
         else targetWidth = targetHeight / cellRatio;
-        //Centrado de las cartas una vez se ha conservado el aspect ratio:
-        horizontalPadding = (rectTransform.rect.width - (targetWidth * numColumns + 
+
+        horizontalPadding = (rectTransform.rect.width - (targetWidth * numColumns +
             (numColumns - 1) * horizontalSpacing)) / 2;
-        verticalPadding = (rectTransform.rect.height - (targetHeight * numRows + (numRows - 1) * 
+        verticalPadding = (rectTransform.rect.height - (targetHeight * numRows + (numRows - 1) *
             verticalSpacing)) / 2;
-        //Colocación de las cartas:
+
         float startXPos = horizontalPadding + targetWidth / 2 + horizontalPadding * horizontalOffset;
-        float startYPos = - (verticalPadding + targetHeight / 2) + verticalPadding * verticalOffset;
-        int incompletedCount = 0; //Número de cartas de una fila incompleta
+        float startYPos = -(verticalPadding + targetHeight / 2) + verticalPadding * verticalOffset;
+        int incompletedCount = 0;
         for (int i = 0; i < numRows; i++)
         {
-            for(int j = 0; j < numColumns; j++)
+            for (int j = 0; j < numColumns; j++)
             {
                 float offsetX = startXPos + (horizontalSpacing + targetWidth) * j;
                 float offsetY = startYPos - (verticalSpacing + targetHeight) * i;
@@ -91,11 +88,15 @@ public class AdaptiveGridLayout : MonoBehaviour
                     incompletedCount = idx % numColumns;
                     break;
                 }
-                children[idx].anchoredPosition = new Vector2(offsetX, offsetY);
-                children[idx].sizeDelta = new Vector2(targetWidth, targetHeight);
+
+                RectTransform child = children[idx];
+                if (child == null) continue;
+
+                child.anchoredPosition = new Vector2(offsetX, offsetY);
+                child.sizeDelta = new Vector2(targetWidth, targetHeight);
             }
         }
-        //Centrado de filas incompletas:
+
         if (!centerIncompleteRows || incompletedCount == 0) return;
         horizontalPadding = (rectTransform.rect.width - (targetWidth * incompletedCount +
             (incompletedCount - 1) * horizontalSpacing)) / 2;
@@ -104,7 +105,27 @@ public class AdaptiveGridLayout : MonoBehaviour
         {
             float offsetX = startXPos + (horizontalSpacing + targetWidth) * i;
             int idx = incompletedCount - i;
-            children[^idx].anchoredPosition = new Vector2(offsetX, children[^idx].anchoredPosition.y);
+            RectTransform child = children[^idx];
+            if (child == null) continue;
+            child.anchoredPosition = new Vector2(offsetX, child.anchoredPosition.y);
+        }
+    }
+
+    private void RefreshChildren()
+    {
+        rectTransform = GetComponent<RectTransform>();
+        children.Clear();
+        for (int i = 0; i < transform.childCount; i++)
+        {
+            Transform child = transform.GetChild(i);
+            if (excludedObjects.Contains(child)) continue;
+
+            RectTransform rt = child.GetComponent<RectTransform>();
+            if (rt == null) continue;
+
+            rt.anchorMin = new Vector2(0f, 1f);
+            rt.anchorMax = new Vector2(0f, 1f);
+            children.Add(rt);
         }
     }
 }

--- a/Assets/Scripts/UI/GameSettings.cs
+++ b/Assets/Scripts/UI/GameSettings.cs
@@ -11,24 +11,40 @@ public class GameSettings : MonoBehaviour
     [SerializeField] private AudioMixer mixer;
     private FontDropdown fontDropdown;
 
-    private void Start()
+    private void Awake()
     {
         fontDropdown = GetComponentInChildren<FontDropdown>();
-        showSpacesToggle.isOn = PlayerPrefs.GetInt("ShowSpaces", 1) == 1;
-        SetShowSpaces(showSpacesToggle.isOn);
-        capLocksWarningToggle.isOn = PlayerPrefs.GetInt("CapLocksWarnigng", 0) == 1;
-        SetCapsWarning(capLocksWarningToggle.isOn);
-        volumeSlider.value = PlayerPrefs.GetFloat("Volume", 0.75f);
-        SetVolume(volumeSlider.value);
-        fontDropdown.SetFont(PlayerPrefs.GetInt("Font", 0));
+    }
+
+    private void OnEnable()
+    {
+        SaveManager.Instance.OnBeforeSave += HandleBeforeSave;
+        SaveManager.Instance.OnAfterLoad += HandleAfterLoad;
+    }
+
+    private void Start()
+    {
+        if (SaveManager.Instance.TryGetSnapshot(out SaveState state))
+        {
+            ApplySettings(state);
+        }
+        else
+        {
+            ApplySettings(new SaveState());
+        }
+    }
+
+    private void OnDisable()
+    {
+        if (SaveManager.Instance == null) return;
+
+        SaveManager.Instance.OnBeforeSave -= HandleBeforeSave;
+        SaveManager.Instance.OnAfterLoad -= HandleAfterLoad;
     }
 
     public void Save()
     {
-        PlayerPrefs.SetInt("ShowSpaces", showSpacesToggle.isOn ? 1 : 0);
-        PlayerPrefs.SetInt("CapLocksWarnigng", capLocksWarningToggle.isOn ? 1 : 0);
-        PlayerPrefs.SetFloat("Volume", volumeSlider.value);
-        PlayerPrefs.SetInt("Font", fontDropdown.CurrentFontIdx);
+        SaveManager.Instance.Save();
     }
 
     public void ToggleShowSpaces() => showSpacesToggle.isOn = !showSpacesToggle.isOn;
@@ -48,5 +64,34 @@ public class GameSettings : MonoBehaviour
         float maxDB = 20f;
         float logValue = Mathf.Log10(1f + value * 9f) / Mathf.Log10(10f);
         mixer.SetFloat("MasterVolume", Mathf.Lerp(minDB, maxDB, logValue));
+    }
+
+    private void HandleBeforeSave(SaveState state)
+    {
+        state.global.showSpaces = showSpacesToggle.isOn;
+        state.global.capsLockWarning = capLocksWarningToggle.isOn;
+        state.global.volume = volumeSlider.value;
+        state.global.fontIndex = fontDropdown.CurrentFontIdx;
+    }
+
+    private void HandleAfterLoad(SaveState state)
+    {
+        ApplySettings(state);
+    }
+
+    private void ApplySettings(SaveState state)
+    {
+        GlobalSettingsData data = state.global ?? new GlobalSettingsData();
+
+        showSpacesToggle.isOn = data.showSpaces;
+        SetShowSpaces(data.showSpaces);
+
+        capLocksWarningToggle.isOn = data.capsLockWarning;
+        SetCapsWarning(data.capsLockWarning);
+
+        volumeSlider.value = data.volume;
+        SetVolume(data.volume);
+
+        fontDropdown.SetFont(data.fontIndex);
     }
 }

--- a/Assets/Scripts/UI/InitialTip.cs
+++ b/Assets/Scripts/UI/InitialTip.cs
@@ -4,20 +4,76 @@ public class InitialTip : MonoBehaviour
 {
     [SerializeField] private Canvas mainMenuCanvas;
     private Canvas selfCanvas;
+    private bool hasBeenUnderstood;
 
     private void Awake()
     {
         selfCanvas = GetComponent<Canvas>();
-        if (PlayerPrefs.GetInt("Understood", 0) != 1)
+    }
+
+    private void OnEnable()
+    {
+        SaveManager.Instance.OnBeforeSave += HandleBeforeSave;
+        SaveManager.Instance.OnAfterLoad += HandleAfterLoad;
+    }
+
+    private void Start()
+    {
+        if (SaveManager.Instance.TryGetSnapshot(out SaveState state))
         {
-            selfCanvas.enabled = true;
-            mainMenuCanvas.enabled = false;
+            ApplyState(state);
         }
+        else
+        {
+            ShowTip();
+        }
+    }
+
+    private void OnDisable()
+    {
+        if (SaveManager.Instance == null) return;
+
+        SaveManager.Instance.OnBeforeSave -= HandleBeforeSave;
+        SaveManager.Instance.OnAfterLoad -= HandleAfterLoad;
     }
 
     public void Understood()
     {
-        PlayerPrefs.SetInt("Understood", 1);
+        hasBeenUnderstood = true;
+        HideTip();
+        SaveManager.Instance.Save();
+    }
+
+    private void HandleBeforeSave(SaveState state)
+    {
+        state.global.initialTipUnderstood = hasBeenUnderstood;
+    }
+
+    private void HandleAfterLoad(SaveState state)
+    {
+        ApplyState(state);
+    }
+
+    private void ApplyState(SaveState state)
+    {
+        hasBeenUnderstood = state.global.initialTipUnderstood;
+        if (hasBeenUnderstood)
+        {
+            HideTip();
+            return;
+        }
+
+        ShowTip();
+    }
+
+    private void ShowTip()
+    {
+        selfCanvas.enabled = true;
+        mainMenuCanvas.enabled = false;
+    }
+
+    private void HideTip()
+    {
         selfCanvas.enabled = false;
         mainMenuCanvas.enabled = true;
     }

--- a/Assets/Scripts/UI/ProfileSettings.cs
+++ b/Assets/Scripts/UI/ProfileSettings.cs
@@ -9,39 +9,46 @@ public class ProfileSettings : MonoBehaviour
 {
     [SerializeField] private TextMeshProUGUI usernameText;
     [SerializeField] private TextMeshProUGUI helpText;
-    private string defaultUsername = "AverageCultist";
-    
-    private string currentName = "";
-    private bool isTyping = false;
+    private readonly string defaultUsername = "AverageCultist";
+
+    private string currentName = string.Empty;
+    private bool isTyping;
     private WritableButton usernameButton;
     private WritableButton[] allWritableButtons;
-    private int minNameLength = 4;
-    private int maxNameLength = 15;
+    private readonly int minNameLength = 4;
+    private readonly int maxNameLength = 15;
 
-    private void Start()
+    private void Awake()
     {
         allWritableButtons = GetComponentsInChildren<Button>().Select(b => b.GetComponent<WritableButton>()).ToArray();
         usernameButton = usernameText.GetComponentInParent<WritableButton>();
-        currentName = PlayerPrefs.GetString("Username", defaultUsername);
+    }
 
-        if (string.IsNullOrWhiteSpace(currentName))
+    private void OnEnable()
+    {
+        SaveManager.Instance.OnBeforeSave += HandleBeforeSave;
+        SaveManager.Instance.OnAfterLoad += HandleAfterLoad;
+    }
+
+    private void Start()
+    {
+        if (SaveManager.Instance.TryGetSnapshot(out SaveState state))
         {
-            currentName = defaultUsername;
+            ApplyProfile(state);
         }
-
-        if (currentName.Equals(defaultUsername))
+        else
         {
-            currentName += "#";
-            for (int i = 0; i < 4; i++) currentName += Random.Range(0, 10).ToString();
+            currentName = GenerateDisplayName(defaultUsername);
+            usernameButton.OverrideText(currentName);
         }
+    }
 
-        usernameButton.OverrideText(currentName);
+    private void OnDisable()
+    {
+        if (SaveManager.Instance == null) return;
 
-        if (!PlayerPrefs.HasKey("Username"))
-        {
-            PlayerPrefs.SetString("Username", currentName);
-            PlayerPrefs.Save();
-        }
+        SaveManager.Instance.OnBeforeSave -= HandleBeforeSave;
+        SaveManager.Instance.OnAfterLoad -= HandleAfterLoad;
     }
 
     private void Update()
@@ -65,16 +72,13 @@ public class ProfileSettings : MonoBehaviour
         if (isTyping) return;
         usernameButton.Block = true;
         isTyping = true;
-        currentName = "";
+        currentName = string.Empty;
         usernameButton.OverrideText(currentName);
 
         helpText.enabled = true;
         helpText.text = "Press enter to save name";
 
-        // Deshabilitar el resto de botones
         ToggleWritableButtons(true);
-
-        // Usar el listener del input handler
         InputHandler.Instance.AddListener(OnCharacterTyped);
     }
 
@@ -95,21 +99,22 @@ public class ProfileSettings : MonoBehaviour
             InputHandler.Instance.RemoveListener(OnCharacterTyped);
         }
 
-        // habilitar el resto de botones
         ToggleWritableButtons(false);
         currentName = currentName.Trim();
-        // Comprobar si el usuario es válido y guardar
         if (CheckText(currentName))
         {
             helpText.text = "Name saved!";
-
-            PlayerPrefs.SetString("Username", currentName);
-            PlayerPrefs.Save();
+            SaveManager.Instance.Save();
+        }
+        else if (SaveManager.Instance.TryGetSnapshot(out SaveState state))
+        {
+            ApplyProfile(state);
         }
         else
         {
-            currentName = PlayerPrefs.GetString("Username", defaultUsername);
+            currentName = GenerateDisplayName(defaultUsername);
         }
+
         usernameButton.OverrideText(currentName);
         usernameButton.Block = false;
     }
@@ -153,7 +158,6 @@ public class ProfileSettings : MonoBehaviour
 
     private void OnDestroy()
     {
-        // Seguridad por si el objeto se destruye a mitad de la escritura
         if (isTyping && InputHandler.Instance != null)
         {
             InputHandler.Instance.RemoveListener(OnCharacterTyped);
@@ -163,5 +167,42 @@ public class ProfileSettings : MonoBehaviour
     public void LinkAccount()
     {
         Debug.Log("Not implemented yet");
+    }
+
+    private void HandleBeforeSave(SaveState state)
+    {
+        state.slot.profile.username = currentName.Trim();
+    }
+
+    private void HandleAfterLoad(SaveState state)
+    {
+        ApplyProfile(state);
+    }
+
+    private void ApplyProfile(SaveState state)
+    {
+        currentName = GenerateDisplayName(state?.slot?.profile?.username);
+
+        if (usernameButton != null)
+        {
+            usernameButton.OverrideText(currentName);
+        }
+    }
+
+    private string GenerateDisplayName(string candidate)
+    {
+        string normalized = string.IsNullOrWhiteSpace(candidate) ? defaultUsername : candidate.Trim();
+        if (!normalized.Equals(defaultUsername))
+        {
+            return normalized;
+        }
+
+        string generated = normalized + "#";
+        for (int i = 0; i < 4; i++)
+        {
+            generated += Random.Range(0, 10).ToString();
+        }
+
+        return generated;
     }
 }

--- a/game.slnx
+++ b/game.slnx
@@ -1,3 +1,4 @@
 ﻿<Solution>
   <Project Path="Assembly-CSharp.csproj" />
+  <Project Path="Assembly-CSharp-Editor.csproj" />
 </Solution>


### PR DESCRIPTION
## Summary

This PR introduces a new save system for the Unity project based on a unified `SaveState` API.

The system now centralizes persistence in `SaveManager`, keeps slot data and global settings separated internally, and exposes a single state model to the rest of the game. It also migrates the main existing persistence consumers away from direct `PlayerPrefs` usage.

## What changed

- Added a new save system under `Assets/Scripts/SaveSystem`
- Introduced `SaveState` as the public persistence model
- Kept slot-scoped data and global data separated internally
- Added `SaveManager` as a `ScriptableSingleton`
- Added save backends for file storage and `PlayerPrefs`
- Added encryption support shared by both backends
- Added defensive error handling for save/load operations
- Centralized save-related keys in `SaveKeys`

## Gameplay/UI migration

The following systems were migrated to the new save flow:

- `ProfileSettings`
- `GameSettings`
- `DeckBuilder`
- `InitialTip`
- `Player` name loading

These now use `SaveManager` events and snapshots instead of reading persistence directly.

## Editor tooling

- Added a `Tools/Save Data/Delete All Saved Game Data` editor action
- This removes save-system data without modifying the existing `PlayerPrefsDeleter`

## Additional fixes

- Updated `AdaptiveGridLayout` to handle destroyed/rebuilt UI children safely
- This fixes errors caused by deck UI elements being recreated during load/update flows

## Architecture notes

- Public API is now unified around `SaveState`
- Slot logic remains encapsulated inside `SaveManager`
- Persistence format/backends remain replaceable
- Legacy save compatibility was removed because the project is still in alpha and only used internally by devs

## Risks / Notes

- Existing local dev data stored only through the old legacy path will no longer be migrated automatically
- Save files are now encrypted through the backend layer
- `SaveManager` lifecycle now relies on explicit initialization instead of `MonoBehaviour` scene lifetime
